### PR TITLE
feat(crawler): add random pause intervals to crawling process

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -1,4 +1,6 @@
 import requests
+import time
+import random 
 from collections import deque
 from urllib.parse import urlparse
 from parser import parse_page
@@ -24,9 +26,17 @@ def crawl_site(base_url, max_pages):
     visited = {start_url}
     base_netloc = urlparse(start_url).netloc.replace("www.", "")
 
+    next_pause_at = random.randint(50, 100)
+    
     while queue and len(crawled_data) < max_pages:
         url = queue.popleft()
         print(f"Crawling [{len(crawled_data) + 1}/{max_pages}]: {url}")
+
+        if len(crawled_data) > 0 and (len(crawled_data) % 100 == 0 or len(crawled_data) == next_pause_at):
+            wait_time = random.randint(300, 800)  # 5 a 10 minutos en segundos
+            print(f"Pausing for {wait_time // 60} minutes ({wait_time} seconds) to avoid being blocked...")
+            time.sleep(wait_time)
+            next_pause_at = len(crawled_data) + random.randint(30, 80)
 
         try:
             head_response = requests.head(url, headers=HEADERS, timeout=5, allow_redirects=True)
@@ -39,7 +49,7 @@ def crawl_site(base_url, max_pages):
             
             if "text/html" not in content_type:
                 print(f"  -> Skipping non-HTML content: {content_type}")
-                visited.add(final_url) # Mark as visited so we don't check it again
+                visited.add(final_url)
                 continue
 
         except requests.RequestException as e:

--- a/crawler.py
+++ b/crawler.py
@@ -33,7 +33,7 @@ def crawl_site(base_url, max_pages):
         print(f"Crawling [{len(crawled_data) + 1}/{max_pages}]: {url}")
 
         if len(crawled_data) > 0 and (len(crawled_data) % 100 == 0 or len(crawled_data) == next_pause_at):
-            wait_time = random.randint(300, 800)  # 5 a 10 minutos en segundos
+            wait_time = random.randint(300, 800)  # 5 to 10 minutes in seconds
             print(f"Pausing for {wait_time // 60} minutes ({wait_time} seconds) to avoid being blocked...")
             time.sleep(wait_time)
             next_pause_at = len(crawled_data) + random.randint(30, 80)


### PR DESCRIPTION
feat(crawler): add random pause intervals to crawling process

The crawler now pauses for a random duration (5–13 minutes) after every 100 pages or when reaching a random threshold between 50 and 100 pages. After each pause, a new random threshold (30–80 pages) is set for the next pause. This helps reduce the risk of being blocked